### PR TITLE
update: build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'network.abmatrix.sgx_client'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.9.0'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
```shell
The Android Gradle plugin supports only Kotlin Gradle plugin version 1.5.20 and higher.
The following dependencies do not satisfy the required version:
project ':sgx_client' -> org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50
```